### PR TITLE
Updates to create_per_gene_matrix.py

### DIFF
--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -149,6 +149,7 @@ def get_csq_pair_combo_map() -> Tuple[List[str], hl.expr.DictExpression]:
 def get_cum_csq_map() -> hl.expr.DictExpression:
     """
     Get expression mapping a CSQ code index to all cumulative CSQs that it belongs to.
+    
     For example, 0 (lof) is included in the following cumulative consequences:
         - lof
         - strong_revel_missense_or_worse

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -150,6 +150,7 @@ def get_cum_csq_map() -> hl.expr.DictExpression:
     """
     Get expression mapping a CSQ code index to all cumulative CSQs that it belongs to.
     
+
     For example, 0 (lof) is included in the following cumulative consequences:
         - lof
         - strong_revel_missense_or_worse

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -339,8 +339,9 @@ def compute_from_vp_mt(test: bool, overwrite: bool) -> None:
 
     logger.info(
         "Filtering variant pair MatrixTable rows to variant pairs with both PASS variants and "
-        "both AF <= %f in bottlenecked populations (fin, asj, oth)...",
+        "both AF <= %f in bottlenecked populations: %s ...",
         BOTTLENECKED_CUTOFF,
+        BOTTLENECKED_POPS,
     )
     vp_mt = vp_mt.filter_rows(
         ~vp_mt.filtered

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -36,6 +36,7 @@ ALLELE_FREQUENCY_CUTOFFS = {
     0.00001,
 }
 BOTTLENECKED_CUTOFF = 0.05
+BOTTLENECKED_POPS = ["fin", "asj", "oth"]
 STRONG_REVEL_CUTOFF = 0.932
 MODERATE_REVEL_CUTOFF = 0.773
 SUPPORTING_REVEL_CUTOFF = 0.644
@@ -53,7 +54,6 @@ CSQ_COMBOS = list(combinations_with_replacement(CSQ_CODES, 2))
 CSQ_IDX_COMBOS = list(combinations_with_replacement(range(LEN_CSQ_CODES), 2))
 LEN_CSQ_COMBOS = len(CSQ_COMBOS)
 PHASE_GROUPS = ["chet", "same_hap", "unphased"]
-BOTTLENECKED_POPS = ["fin", "asj", "oth"]
 
 
 def filter_to_test(
@@ -421,7 +421,7 @@ def compute_from_vp_mt(test: bool, overwrite: bool) -> None:
         "and 'same_hap' (allowing samples to be counted in >1 co-occurrence grouping per gene, if applicable), "
         "counts for 'any_het_het' (samples with two heterozygous variants regardless of phase), "
         "and counts for 'unphased' and 'same hap' prioritizing counts of chet > unphased > same_hap (restricing individuals "
-        "to only the most severe co-occurrence grouping, by gene_id, gene_symbol, csq, and af_cutoff..."
+        "to only the most severe co-occurrence grouping, by gene_id, gene_symbol, csq, and af_cutoff)..."
     )
     gene_ht = vp_mt.annotate_rows(
         **{
@@ -473,8 +473,9 @@ def compute_from_full_mt(test: bool, overwrite: bool) -> None:
     logger.info(
         "Annotating full MatrixTable with VEP, filter information, annotation indicating all relevant consequence "
         "groupings for the variant (matching the annotation used in compute_from_vp_mt), "
-        "bottlenecked population AF (fin, asj, oth), and all relevant allele frequencies for filtering "
+        "bottlenecked population AF (%s), and all relevant allele frequencies for filtering "
         "(variant popmax or global AF <= AF cutoff for the following cutoffs: %s)...",
+        BOTTLENECKED_POPS,
         ALLELE_FREQUENCY_CUTOFFS,
     )
     mt = mt.select_rows(
@@ -485,9 +486,10 @@ def compute_from_full_mt(test: bool, overwrite: bool) -> None:
     )
 
     logger.info(
-        "Filtering MatrixTable to PASS variants with VEP information, AF <= %f in bottlenecked populations "
-        "(fin, asj, oth) and popmax or global AF <= %f)...",
+        "Filtering MatrixTable to PASS variants with VEP information, AF <= %f in bottlenecked populations: "
+        "%s and popmax or global AF <= %f)...",
         BOTTLENECKED_CUTOFF,
+        BOTTLENECKED_POPS,
         max(ALLELE_FREQUENCY_CUTOFFS),
     )
     mt = mt.filter_rows(

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -99,6 +99,7 @@ def get_csq_pair_combo_map() -> Tuple[List[str], hl.expr.DictExpression]:
         - missense_or_worse_missense_or_worse
         - missense_or_worse_synonymous_or_worse
         - synonymous_or_worse_synonymous_or_worse
+    
     :return: Tuple with the list of possible CSQ pairs and a Dictionary expression mapping a CSQ code index to all
         cumulative CSQs that it belongs to.
     """

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -305,7 +305,11 @@ def compute_from_vp_mt(test: bool, overwrite: bool) -> None:
             ann_ht.freq2["all"].AF, 
             filter_missing=True,
         ),
-        bottlenecked_af=hl.max(ann_ht.freq1["fin"].AF, ann_ht.freq1["asj"].AF, ann_ht.freq1["oth"].AF, ann_ht.freq2["fin"].AF, ann_ht.freq2["asj"].AF, ann_ht.freq2["oth"].AF, filter_missing=True),
+        bottlenecked_af=hl.max(
+            *[ann_ht.freq1[pop].AF for pop in BOTTLENECKED_POPS], 
+            *[ann_ht.freq2[pop].AF for pop in BOTTLENECKED_POPS], 
+            filter_missing=True
+        ),
         filtered=(hl.len(ann_ht.filters1) > 0) | (hl.len(ann_ht.filters2) > 0),
         vep=vep1_expr.keys()
         .filter(lambda k: vep2_expr.contains(k))

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -206,7 +206,7 @@ def get_worst_gene_csq_code_expr_revel(
         - synonymous
 
     :param vep_expr: Expression containing VEP information for the variant.
-    :param revel_expr: Expression containing the Revel score for the variant.
+    :param revel_expr: Expression containing the REVEL score for the variant.
     :return: Dictionary expression mapping gene ID to the worst consequence.
     """
     worst_gene_csq_expr = vep_expr.transcript_consequences.filter(
@@ -423,7 +423,7 @@ def compute_from_vp_mt(test: bool, overwrite: bool) -> None:
         "Performing final aggregation to get sample counts for co-occurrence groupings 'chet', 'unphased', "
         "and 'same_hap' (allowing samples to be counted in >1 co-occurrence grouping per gene, if applicable), "
         "counts for 'any_het_het' (samples with two heterozygous variants regardless of phase), "
-        "and counts for 'unphased' and 'same hap' prioritizing counts of chet > unphased > same_hap (restricing individuals "
+        "and counts for 'unphased' and 'same hap' prioritizing counts of chet > unphased > same_hap (restricting individuals "
         "to only the most severe co-occurrence grouping, by gene_id, gene_symbol, csq, and af_cutoff)..."
     )
     gene_ht = vp_mt.annotate_rows(
@@ -466,7 +466,7 @@ def compute_from_full_mt(test: bool, overwrite: bool) -> None:
 
     logger.info(
         "Getting the expression for the worst gene consequence of the canonical "
-        "transcript per gene using Revel scores for missense variants and adding an annotation "
+        "transcript per gene using REVEL scores for missense variants and adding an annotation "
         "indicating all relevant consequence groupings for the variant..."
     )
     vep_expr = get_worst_gene_csq_code_expr_revel(

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -53,6 +53,7 @@ CSQ_COMBOS = list(combinations_with_replacement(CSQ_CODES, 2))
 CSQ_IDX_COMBOS = list(combinations_with_replacement(range(LEN_CSQ_CODES), 2))
 LEN_CSQ_COMBOS = len(CSQ_COMBOS)
 PHASE_GROUPS = ["chet", "same_hap", "unphased"]
+BOTTLENECKED_POPS = ["fin", "asj", "oth"]
 
 
 def filter_to_test(

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -210,23 +210,23 @@ def get_worst_gene_csq_code_expr_revel(
                 hl.case(missing_false=True)
                 .when(ts.lof == "HC", CSQ_CODES.index("lof"))
                 .when(
-                    (ts.consequence_terms.all(lambda x: x == "missense_variant") & (revel_expr >= STRONG_REVEL_CUTOFF)),
+                    (ts.consequence_terms.any(lambda x: x == "missense_variant") & (revel_expr >= STRONG_REVEL_CUTOFF)),
                     CSQ_CODES.index("strong_revel_missense"),
                 )
                 .when(
-                    (ts.consequence_terms.all(lambda x: x == "missense_variant") & (revel_expr >= MODERATE_REVEL_CUTOFF)),
+                    (ts.consequence_terms.any(lambda x: x == "missense_variant") & (revel_expr >= MODERATE_REVEL_CUTOFF)),
                     CSQ_CODES.index("moderate_to_strong_revel_missense"),
                 )
                 .when(
-                    (ts.consequence_terms.all(lambda x: x == "missense_variant") & (revel_expr >= SUPPORTING_REVEL_CUTOFF)),
+                    (ts.consequence_terms.any(lambda x: x == "missense_variant") & (revel_expr >= SUPPORTING_REVEL_CUTOFF)),
                     CSQ_CODES.index("supporting_to_strong_revel_missense"),
                 )
                 .when(
-                    ts.consequence_terms.all(lambda x: x == "missense_variant"),
+                    ts.consequence_terms.any(lambda x: x == "missense_variant"),
                     CSQ_CODES.index("missense"),
                 )
                 .when(
-                    ts.consequence_terms.all(lambda x: x == "synonymous_variant"),
+                    ts.consequence_terms.any(lambda x: x == "synonymous_variant"),
                     CSQ_CODES.index("synonymous"),
                 )
                 .or_missing()

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -203,6 +203,7 @@ def get_worst_gene_csq_code_expr_revel(
         - supporting_to_strong_revel_missense
         - missense
         - synonymous
+
     :param vep_expr: Expression containing VEP information for the variant.
     :param revel_expr: Expression containing the Revel score for the variant.
     :return: Dictionary expression mapping gene ID to the worst consequence.

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -298,7 +298,13 @@ def compute_from_vp_mt(test: bool, overwrite: bool) -> None:
         "snv1",
         "snv2",
         is_singleton_vp=(ann_ht.freq1["all"].AC < 2) & (ann_ht.freq2["all"].AC < 2),
-        popmax_or_global_af=hl.max(ann_ht.popmax1.AF, ann_ht.popmax2.AF, ann_ht.freq1["all"].AF, ann_ht.freq2["all"].AF, filter_missing=True),
+        popmax_or_global_af=hl.max(
+            ann_ht.popmax1.AF, 
+            ann_ht.popmax2.AF, 
+            ann_ht.freq1["all"].AF, 
+            ann_ht.freq2["all"].AF, 
+            filter_missing=True,
+        ),
         bottlenecked_af=hl.max(ann_ht.freq1["fin"].AF, ann_ht.freq1["asj"].AF, ann_ht.freq1["oth"].AF, ann_ht.freq2["fin"].AF, ann_ht.freq2["asj"].AF, ann_ht.freq2["oth"].AF, filter_missing=True),
         filtered=(hl.len(ann_ht.filters1) > 0) | (hl.len(ann_ht.filters2) > 0),
         vep=vep1_expr.keys()

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -195,6 +195,7 @@ def get_worst_gene_csq_code_expr_revel(
 ) -> hl.expr.DictExpression:
     """
     Filter VEP transcript consequences to canonical and protein coding and annotate with the worst consequence.
+    
     Consequence order worst to least:
         - lof
         - strong_revel_missense

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -60,6 +60,7 @@ def filter_to_test(
 ) -> List[Union[hl.Table, hl.MatrixTable]]:
     """
     Filter any Tables in the list to chr20, and any MatrixTables in the list to the first 20 partitions on chr20.
+    
     :param tables: List of Tables and/or MatrixTables to filter for testing
     :return: List of filtered Tables and/or MatrixTables
     """

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -254,6 +254,7 @@ def get_worst_gene_csq_code_expr_revel(
 def compute_from_vp_mt(test: bool, overwrite: bool) -> None:
     """
     Compute sample counts by predicted phase, AF, and functional csq from variant pair MatrixTable.
+
     :param test: Whether to filter the variant pair MatrixTable to the first 20 partitions for testing.
     :param overwrite: Whether to overwrite the final output.
     :return: None

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -328,8 +328,13 @@ def compute_from_vp_mt(test: bool, overwrite: bool) -> None:
         "both AF <= %f in bottlenecked populations (fin, asj, oth)...",
         BOTTLENECKED_CUTOFF,
     )
-    vp_mt = vp_mt.filter_rows(~vp_mt.filtered)
-    vp_mt = vp_mt.filter_rows((vp_mt.bottlenecked_af <= BOTTLENECKED_CUTOFF) | hl.is_missing(vp_mt.bottlenecked_af))
+    vp_mt = vp_mt.filter_rows(
+        ~vp_mt.filtered
+        & (
+            hl.is_missing(vp_mt.bottlenecked_af)
+            | (vp_mt.bottlenecked_af <= BOTTLENECKED_CUTOFF)
+        )
+    )
 
     logger.info(
         "Filtering variant pair MatrixTable entries keeping only entries where both variants have a het GT and pass "

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -226,7 +226,10 @@ def get_worst_gene_csq_code_expr_revel(
                     CSQ_CODES.index("moderate_to_strong_revel_missense"),
                 )
                 .when(
-                    (ts.consequence_terms.any(lambda x: x == "missense_variant") & (revel_expr >= SUPPORTING_REVEL_CUTOFF)),
+                    (
+                        ts.consequence_terms.any(lambda x: x == "missense_variant") 
+                        & (revel_expr >= SUPPORTING_REVEL_CUTOFF)
+                    ),
                     CSQ_CODES.index("supporting_to_strong_revel_missense"),
                 )
                 .when(

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -77,6 +77,7 @@ def filter_to_test(
 def get_csq_pair_combo_map() -> Tuple[List[str], hl.expr.DictExpression]:
     """
     Get list of possible CSQ pairs and a mapping of the CSQ pair code index to all cumulative CSQs that it belongs to.
+    
     For example, 0 (lof_lof) is included in the following cumulative consequences:
         - lof_strong_revel_missense_or_worse
         - lof_moderate_revel_missense_or_worse

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -158,6 +158,7 @@ def get_cum_csq_map() -> hl.expr.DictExpression:
         - supporting_revel_missense_or_worse
         - missense_or_worse
         - synonymous_or_worse
+
     :return: Dictionary expression mapping a CSQ code index to all cumulative CSQs that it belongs to.
     """
     # Adds cumulative CSQ codes to indivudual CSQ codes

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -219,7 +219,10 @@ def get_worst_gene_csq_code_expr_revel(
                 hl.case(missing_false=True)
                 .when(ts.lof == "HC", CSQ_CODES.index("lof"))
                 .when(
-                    (ts.consequence_terms.any(lambda x: x == "missense_variant") & (revel_expr >= STRONG_REVEL_CUTOFF)),
+                    (
+                        ts.consequence_terms.any(lambda x: x == "missense_variant")
+                        & (revel_expr >= STRONG_REVEL_CUTOFF)
+                    ),
                     CSQ_CODES.index("strong_revel_missense"),
                 )
                 .when(

--- a/create_per_gene_matrix.py
+++ b/create_per_gene_matrix.py
@@ -226,7 +226,10 @@ def get_worst_gene_csq_code_expr_revel(
                     CSQ_CODES.index("strong_revel_missense"),
                 )
                 .when(
-                    (ts.consequence_terms.any(lambda x: x == "missense_variant") & (revel_expr >= MODERATE_REVEL_CUTOFF)),
+                    (
+                        ts.consequence_terms.any(lambda x: x == "missense_variant") 
+                        & (revel_expr >= MODERATE_REVEL_CUTOFF)
+                    ),
                     CSQ_CODES.index("moderate_to_strong_revel_missense"),
                 )
                 .when(


### PR DESCRIPTION
Hi Julia, I made some updates to the create_per_gene_matrix code, to correct an error and to make updates based on recent project discussions.

To summarise:

I found an error with the missense csq annotation which is now corrected.

After discussion with Anne and Kaitlin we've changed the af filtering:
1) to use global af when popmax is missing
2) to filter out all variants with af >5% in a bottlenecked population.

We also wanted to shift the focus to "two rare variant" counting, so I updated the script to have three functions:
1) generates gene-level matrix table of individuals with 'chet', 'same_hap', 'unphased', and 'het_het' variants
2) generates gene-level matrix table of individuals with 'hom' variants
3) combines the two gene-level matrix tables to give a table of counts for 'chet', 'same_hap', 'unphased', 'het_het', 'hom', 'chet_or_hom', and 'any_two'

(I'm unsure whether this is better as three functions or just one?)